### PR TITLE
Execute unbound after network is online

### DIFF
--- a/roles/unbound/files/unbound.service.d/unbound.conf
+++ b/roles/unbound/files/unbound.service.d/unbound.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=network-online.target

--- a/roles/unbound/handlers/main.yaml
+++ b/roles/unbound/handlers/main.yaml
@@ -1,3 +1,7 @@
+- name: systemd
+  ansible.builtin.systemd:
+    daemon_reload: yes
+
 - name: service
   ansible.builtin.service:
     name: unbound

--- a/roles/unbound/tasks/main.yaml
+++ b/roles/unbound/tasks/main.yaml
@@ -21,6 +21,13 @@
   notify:
     - service
 
+- name: unit
+  ansible.builtin.copy:
+    src: unbound.service.d
+    dest: /etc/systemd/system/
+  notify:
+    - systemd
+
 - name: service
   ansible.builtin.service:
     name: unbound


### PR DESCRIPTION
This PR extends Unbound Systemd service to initialize after network is online.